### PR TITLE
Convert docs to read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: ./requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - testing

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - testing
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=requirements(),
     extras_require={
         "testing": ["pytest"],
-        "examples": [],
+        "docs": ["sphinx", "sphinx_rtd_theme", "numpydoc", "ipykernel", "nbsphinx"],
     },
     python_requires=">=3.8,<3.12",
     classifiers=[


### PR DESCRIPTION
This PR introduces a read the docs documentation build rather than github pages. If this is desired, you can remove the github pages build in a future PR once everything is working and in place. The docs based off this PR can be viewed [here](https://dreimac--16.org.readthedocs.build/en/16/) if you have access to scikit-tda on RTD. If you don't, well they look great! All of the notebooks are compiling and the API links working. If you pass along your RTD username, I can add you to the RTD admin page and you can view it yourself.

I added a `docs` section to `setup.py` rather than a `docs/requirements.txt` file. I prefer this style, since it's easer for a user to install these additional requirements when they install the package (if they desire). If you prefer the latter, I can switch it over.