### PR TITLE
Fixing cocycle lifts with arbitrary integer coefficients

### DIFF
--- a/dreimac/complexprojectivecoords.py
+++ b/dreimac/complexprojectivecoords.py
@@ -132,10 +132,13 @@ class ComplexProjectiveCoords(EMCoords):
                 n_edges = delta2.shape[1]
                 objective = np.zeros((n_edges), dtype=int)
                 integrality = np.ones((n_edges), dtype=int)
+                bounds = scipy.optimize.Bounds()  # empty bounds
+
                 optimizer_solution = milp(
                     objective,
                     integrality=integrality,
                     constraints=constraints,
+                    bounds=bounds,
                 )
 
                 if not optimizer_solution["success"]:

--- a/dreimac/toroidalcoords.py
+++ b/dreimac/toroidalcoords.py
@@ -148,11 +148,13 @@ class ToroidalCoords(EMCoords):
                     n_edges = delta1.shape[1]
                     objective = np.zeros((n_edges))
                     integrality = np.ones((n_edges))
+                    bounds = scipy.optimize.Bounds()  # empty bounds
 
                     optimizer_solution = milp(
                         objective,
                         integrality=integrality,
                         constraints=constraints,
+                        bounds=bounds,
                     )
 
                     if not optimizer_solution["success"]:


### PR DESCRIPTION
Hi, I have just looked at the portion of DREiMac's code responsible for fixing lifts from prime coefficients to integer coefficients, as discussed in [1]. DREiMac does this using a linear program and `scipy.optimize.milp`. However, no `bounds` are passed to the `milp`-solver, which defaults to all variables assumed to be non-negative.

I might be wrong here, but I don't see any reason to enforce the non-negativity. In particular, I can imagine there to be extraordinarily rare cases where a fix depends on negative values to be available.

I have implemented a similar fix to faulty lifted Z/3Z coefficients for homology generators (I.e. cycles) on alpha-complexes in my own project [2], and there the integer linear program _required_ negativity of some of the variables to be feasible (On the TREFOIL knot from DREiMac's documentation).

I have added empty bounds to the uses of milp in `complexprojectivecoords.py` and `toroidalcoords.py`. Sorry if I misunderstood something here! (I have tested the proposed changes using the unit tests and the fix_cocycle notebook and both worked.)

[1] de Silva, V., Morozov, D. & Vejdemo-Johansson, M. Persistent Cohomology and Circular Coordinates. Discrete Comput Geom 45, 737–759 (2011).
[2] [https://github.com/vincent-grande/topf](https://github.com/vincent-grande/topf)