### PR TITLE
Refactor: Change default coordinate value to np.nan

### DIFF
--- a/dreimac/emcoords.py
+++ b/dreimac/emcoords.py
@@ -179,7 +179,7 @@ class EMCoords(object):
         nzero = np.sum(denom == 0)
         if nzero > 0:
             warnings.warn("There are {} point not covered by a landmark".format(nzero))
-            denom[denom == 0] = 1
+            denom[denom == 0] = np.nan
         varphi = phi / denom[None, :]
         # To each data point, associate the index of the first open set it belongs to
         ball_indx = np.argmax(U, 0)


### PR DESCRIPTION
Hi,

I was wondering if it makes sense to return NaN as opposed to the current default behavior of returning 0 for points _outside_ coverage of landmarks. Especially since 0 is a valid coordinate value. 
This way it is easier to identify points outside the coverage of landmarks. 