### PR TITLE
Projective PCA new interface

### DIFF
--- a/dreimac/projectivecoords.py
+++ b/dreimac/projectivecoords.py
@@ -1,6 +1,6 @@
 import numpy as np
 import time
-from .utils import PartUnity, EquivariantPCA
+from .utils import PartUnity, EquivariantPCA, PPCA
 from .emcoords import EMCoords
 
 class ProjectiveCoords(EMCoords):
@@ -35,6 +35,7 @@ class ProjectiveCoords(EMCoords):
             maxdim=maxdim,
             verbose=verbose,
         )
+        self.ppca = None
 
     def get_coordinates(
         self,
@@ -96,9 +97,10 @@ class ProjectiveCoords(EMCoords):
 
         class_map = np.sqrt(varphi.T) * cocycle_matrix[ball_indx[:], :]
 
-        epca = EquivariantPCA.ppca(
-            class_map, proj_dim, projective_dim_red_mode, self.verbose
-        )
-        self._variance = epca["variance"]
+        self.ppca = PPCA(n_components=proj_dim, projective_dim_red_mode= projective_dim_red_mode)
 
-        return epca["X"]
+        X = self.ppca.fit_transform(
+            class_map, self.verbose
+        )
+        self._variance = self.ppca.variance
+        return X

--- a/dreimac/projectivecoords.py
+++ b/dreimac/projectivecoords.py
@@ -45,6 +45,7 @@ class ProjectiveCoords(EMCoords):
         partunity_fn=PartUnity.linear,
         standard_range=True,
         projective_dim_red_mode="exponential",
+        save_projections=False
     ):
         """
         Get real projective coordinates.
@@ -100,7 +101,7 @@ class ProjectiveCoords(EMCoords):
         self.ppca = PPCA(n_components=proj_dim, projective_dim_red_mode= projective_dim_red_mode)
 
         X = self.ppca.fit_transform(
-            class_map, self.verbose
+            class_map, self.verbose, save=save_projections
         )
         self._variance = self.ppca.variance
         return X

--- a/dreimac/utils.py
+++ b/dreimac/utils.py
@@ -736,7 +736,7 @@ class PPCA:
             X = Y / np.linalg.norm(Y, axis=0)[None, :]
             return X, U
 
-    def fit_transform(self, class_map, verbose=False):
+    def fit_transform(self, class_map, verbose=False, save=False):
         '''
         Parameters
         ----------
@@ -749,25 +749,27 @@ class PPCA:
         mode = self.projective_dim_red_mode
         X = class_map.T
         n_dim = class_map.shape[1]
+        projections = number_of_simplices_of_dimension
 
         if mode == "direct":
-            XRet, self.projections = self._fit_direct(X, n_dim, verbose)
+            XRet, self.projections = self._fit_direct(X, n_dim, verbose, save=save)
         elif mode == "exponential":
-            XRet, self.projections = self._fit_exponential(X, n_dim, verbose)
+            XRet, self.projections = self._fit_exponential(X, n_dim, verbose, save=save)
         elif mode == 'one-by-one':
-            XRet, self.projections = self._fit_one_by_one(X, n_dim, verbose)  
+            XRet, self.projections = self._fit_one_by_one(X, n_dim, verbose, save=save)  
         return XRet.T
     
-    def _fit_direct(self, X, n_dim, verbose):
+    def _fit_direct(self, X, n_dim, verbose, save=False):
         ''' Directly fit a projective subspace
         '''
         projections = []
         total_dims_to_keep = self.n_components + 1
         XRet, U = self._one_step_linear_reduction(X, total_dims_to_keep)
-        projections.append(U)
+        if save:
+            projections.append(U)
         return XRet, projections
 
-    def _fit_exponential(self, X, n_dim, verbose):
+    def _fit_exponential(self, X, n_dim, verbose, save=False):
         ''' Reduce half the dimensions
         '''
         projections = []
@@ -777,15 +779,21 @@ class PPCA:
             X, U = self._one_step_linear_reduction(
                 X, total_dims_to_keep + to_keep_this_iter
             )
-            projections.append(U)
+            
+            if save:
+                projections.append(U)
             to_keep_this_iter = to_keep_this_iter // 2
+        
         if X.shape[0] > total_dims_to_keep:
             X, U = self._one_step_linear_reduction(X, total_dims_to_keep)
-            projections.append(U)
+            
+            if save:
+                projections.append(U)
+        
         XRet = X
         return XRet, projections
     
-    def _fit_one_by_one(self, X, n_dim, verbose):
+    def _fit_one_by_one(self, X, n_dim, verbose, save=False):
         proj_dim = self.n_components
         XRet = None
         variance = np.zeros(X.shape[0] - 1)
@@ -796,18 +804,24 @@ class PPCA:
         for i in range(n_dim - 1):
             if i == n_dim - proj_dim - 1:
                 XRet = X
+            
             try:
                 _, U = np.linalg.eigh(X.dot(np.conjugate(X).T))
                 U = np.fliplr(U)
                 # U, _, _ = np.linalg.svd(X)
             except:
                 U = np.eye(X.shape[0])
+            
             variance[-i - 1] = np.mean(
                 (np.pi / 2 - np.real(np.arccos(np.abs(U[:, -1][None, :].dot(X)))))
                 ** 2
             )
+            
             U = U[:,0:-1]
-            projections.append(U)
+
+            if save:
+                projections.append(U)
+            
             Y = (np.conjugate(U).T).dot(X)
             X = Y / np.linalg.norm(Y, axis=0)[None, :]
         
@@ -820,6 +834,8 @@ class PPCA:
 
     def transform(self, class_map):
         '''Project down to fitted projective subspace'''
+        if len(self.projections) == 0:
+            raise ValueError("Projection list empty, please fit and save first!")
         X = class_map.T
         for U in self.projections:
             Y = (np.conjugate(U).T).dot(X)

--- a/dreimac/utils.py
+++ b/dreimac/utils.py
@@ -699,6 +699,133 @@ class PartUnity:
         """
         return np.exp(r_cover**2 / (ds**2 - r_cover**2))
 
+class PPCA:
+    """
+        Principal Projective Component Analysis (Jose Perea 2017)
+
+        Parameters
+        ----------
+        n_components : integer
+            The dimension of the projective space onto which to project
+        projective_dim_red_mode : string
+            Either "one-by-one", "exponential", or "direct". How to perform equivariant
+            dimensionality reduction. "exponential" usually works best, being fast
+            without compromising quality.
+
+    """
+    def __init__(
+            self,
+            n_components=None,
+            projective_dim_red_mode="one-by-one"
+    ):
+        self.n_components = n_components
+        self.projective_dim_red_mode = projective_dim_red_mode
+        self.projections = None
+        assert projective_dim_red_mode in ["direct", "exponential", "one-by-one"]
+
+        self.variance = None
+    
+    def _one_step_linear_reduction(self, X, dims_to_keep):
+            try:
+                _, U = np.linalg.eigh(X.dot(np.conjugate(X).T))
+                U = np.fliplr(U)
+            except:
+                U = np.eye(X.shape[0])
+            U = U[:, :dims_to_keep]
+            Y = (np.conjugate(U).T).dot(X)
+            X = Y / np.linalg.norm(Y, axis=0)[None, :]
+            return X, U
+
+    def fit_transform(self, class_map, verbose=False):
+        '''
+        Parameters
+        ----------
+        class_map : ndarray (N, d)
+            For all N points of the dataset, membership weights to
+            d different classes are the coordinates
+        verbose : boolean
+            Whether to print information during iterations
+        '''
+        mode = self.projective_dim_red_mode
+        X = class_map.T
+        n_dim = class_map.shape[1]
+
+        if mode == "direct":
+            XRet, self.projections = self._fit_direct(X, n_dim, verbose)
+        elif mode == "exponential":
+            XRet, self.projections = self._fit_exponential(X, n_dim, verbose)
+        elif mode == 'one-by-one':
+            XRet, self.projections = self._fit_one_by_one(X, n_dim, verbose)  
+        return XRet.T
+    
+    def _fit_direct(self, X, n_dim, verbose):
+        ''' Directly fit a projective subspace
+        '''
+        projections = []
+        total_dims_to_keep = self.n_components + 1
+        XRet, U = self._one_step_linear_reduction(X, total_dims_to_keep)
+        projections.append(U)
+        return XRet, projections
+
+    def _fit_exponential(self, X, n_dim, verbose):
+        ''' Reduce half the dimensions
+        '''
+        projections = []
+        total_dims_to_keep = self.n_components + 1
+        to_keep_this_iter = (n_dim - total_dims_to_keep) // 2
+        while to_keep_this_iter > 0:
+            X, U = self._one_step_linear_reduction(
+                X, total_dims_to_keep + to_keep_this_iter
+            )
+            projections.append(U)
+            to_keep_this_iter = to_keep_this_iter // 2
+        if X.shape[0] > total_dims_to_keep:
+            X, U = self._one_step_linear_reduction(X, total_dims_to_keep)
+            projections.append(U)
+        XRet = X
+        return XRet, projections
+    
+    def _fit_one_by_one(self, X, n_dim, verbose):
+        proj_dim = self.n_components
+        XRet = None
+        variance = np.zeros(X.shape[0] - 1)
+        projections = []
+        
+        tic = time.time()
+        # Projective dimensionality reduction : Main Loop
+        for i in range(n_dim - 1):
+            if i == n_dim - proj_dim - 1:
+                XRet = X
+            try:
+                _, U = np.linalg.eigh(X.dot(np.conjugate(X).T))
+                U = np.fliplr(U)
+                # U, _, _ = np.linalg.svd(X)
+            except:
+                U = np.eye(X.shape[0])
+            variance[-i - 1] = np.mean(
+                (np.pi / 2 - np.real(np.arccos(np.abs(U[:, -1][None, :].dot(X)))))
+                ** 2
+            )
+            U = U[:,0:-1]
+            projections.append(U)
+            Y = (np.conjugate(U).T).dot(X)
+            X = Y / np.linalg.norm(Y, axis=0)[None, :]
+        
+        self.variance = variance
+        if verbose:
+            print("Elapsed time ppca: %.3g" % (time.time() - tic))
+
+        return XRet, projections
+
+
+    def transform(self, class_map):
+        '''Project down to fitted projective subspace'''
+        X = class_map.T
+        for U in self.projections:
+            Y = (np.conjugate(U).T).dot(X)
+            X = Y / np.linalg.norm(Y, axis=0)[None, :]
+        return X
+
 
 class EquivariantPCA:
     @staticmethod

--- a/test/test_projective.py
+++ b/test/test_projective.py
@@ -24,7 +24,7 @@ class TestRealProjective:
         #theta = np.arccos(np.abs(SOrig[:, 0]))
         
         pc = ProjectiveCoords(D, n_landmarks, distance_matrix=True, verbose=True)
-        coordinates = pc.get_coordinates()
+        coordinates = pc.get_coordinates(projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(X)
         total_variance = np.linalg.norm(pc._variance)
         target_coordinates = 2
@@ -43,7 +43,7 @@ class TestRealProjective:
         r = 1
         X = GeometryExamples.klein_bottle_4d(n_samples, R, r)
         pc = ProjectiveCoords(X, n_landmarks, verbose=True)
-        coordinates = pc.get_coordinates()
+        coordinates = pc.get_coordinates(projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(X)
         total_variance = np.linalg.norm(pc._variance)
         target_coordinates = 2
@@ -58,7 +58,7 @@ class TestRealProjective:
         dim = 10
         P = GeometryExamples.line_patches(dim=dim, n_angles=200, n_offsets=200, sigma=0.25)
         pc = ProjectiveCoords(P, n_landmarks=100)
-        coordinates = pc.get_coordinates()
+        coordinates = pc.get_coordinates(projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(P)
         total_variance = np.linalg.norm(pc._variance)
         target_coordinates = 2
@@ -69,7 +69,7 @@ class TestRealProjective:
     def test_image_patches(self):
         X = GeometryExamples.line_patches(dim=10, n_angles=200, n_offsets=200, sigma=0.25)
         proj = ProjectiveCoords(X, n_landmarks=200)
-        coordinates = proj.get_coordinates(proj_dim=2, perc=0.8, cocycle_idx=0)
+        coordinates = proj.get_coordinates(proj_dim=2, perc=0.8, cocycle_idx=0, projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(X)
         total_variance = np.linalg.norm(proj._variance)
         target_coordinates = 2
@@ -83,7 +83,7 @@ class TestComplexProjective:
         data = GeometryExamples.sphere(2000)
         cpc = ComplexProjectiveCoords(data, n_landmarks=100)
         target_coordinates = 1
-        coordinates = cpc.get_coordinates(proj_dim=target_coordinates)
+        coordinates = cpc.get_coordinates(proj_dim=target_coordinates, projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(data)
         total_variance = np.linalg.norm(cpc._variance)
         variance_threshold = 0.3
@@ -93,7 +93,7 @@ class TestComplexProjective:
         P = GeometryExamples.moving_dot(40)
         cpc = ComplexProjectiveCoords(P, n_landmarks=300)
         target_coordinates = 1
-        coordinates = cpc.get_coordinates(proj_dim=target_coordinates)
+        coordinates = cpc.get_coordinates(proj_dim=target_coordinates, projective_dim_red_mode='one-by-one')
         assert len(coordinates) == len(P)
         total_variance = np.linalg.norm(cpc._variance)
         variance_threshold = 0.3


### PR DESCRIPTION
Hi,

This is a new interface that allows the user to save the projections computed during projective PCA. 

Major changes:
- Add a `PPCA` class with `fit_transform` and `transform` interface similar to sklearn PCA implementation. 
- Add `save_projections` flag to `ProjectiveCoords` and `ComplexProjectiveCoords`
